### PR TITLE
change how the bubble hides in rg-bubble

### DIFF
--- a/tags/bubble/rg-bubble.tag
+++ b/tags/bubble/rg-bubble.tag
@@ -51,7 +51,7 @@
 			font-size: 0.9em;
 			line-height: 1;
 			white-space: nowrap;
-			opacity: 0;
+			display: none;
 		}
 
 		.isvisible {

--- a/themes/material/alerts.scss
+++ b/themes/material/alerts.scss
@@ -1,1 +1,0 @@
-// Put the SCSS into a separate scss file per component please


### PR DESCRIPTION
Currently the bubble is set to 'opacity:0'; this meant that the bubble will interact with content when not visible. One can, for example, select the text with the mouse with the bubble not visible. Changing to 'display:none' removes the bubble form the DOM until it is activated.