### PR TITLE
<rg-chart> crashes on `unmount`: fixes #97

### DIFF
--- a/dist/rg-chart/rg-chart.js
+++ b/dist/rg-chart/rg-chart.js
@@ -7,9 +7,9 @@ this.on('mount', function () {
   drawChart();
 });
 
-this.on('loaded', function (chart) {
+this.on('loaded', function (instance) {
   _this.on('unmount', function () {
-    chart.destroy();
+    instance.destroy();
   });
 });
 
@@ -18,26 +18,27 @@ var drawChart = function drawChart() {
 
   var ctx = _this.root.querySelector('canvas').getContext('2d');
   var chart = new Chart(ctx);
+  var instance = null;
   switch (opts.chart.type) {
     case 'line':
-      chart.Line(opts.chart.data, opts.chart.options);
+      instance = chart.Line(opts.chart.data, opts.chart.options);
       break;
     case 'radar':
-      chart.Radar(opts.chart.data, opts.chart.options);
+      instance = chart.Radar(opts.chart.data, opts.chart.options);
       break;
     case 'polar':
-      chart.PolarArea(opts.chart.data, opts.chart.options);
+      instance = chart.PolarArea(opts.chart.data, opts.chart.options);
       break;
     case 'pie':
-      chart.Pie(opts.chart.data, opts.chart.options);
+      instance = chart.Pie(opts.chart.data, opts.chart.options);
       break;
     case 'doughnut':
-      chart.Doughnut(opts.chart.data, opts.chart.options);
+      instance = chart.Doughnut(opts.chart.data, opts.chart.options);
       break;
     default:
-      chart.Bar(opts.chart.data, opts.chart.options);
+      instance = chart.Bar(opts.chart.data, opts.chart.options);
       break;
   }
-  _this.trigger('loaded', chart);
+  _this.trigger('loaded', instance);
 };
 });


### PR DESCRIPTION
the call to `chart.destroy()` crashes the app when the `<rg-chart>` tag unmounts.

This is because the object passed to the `loaded` event handler is the wrong object, and should be the result of creating a chart, not just `new Chart(ctx)`

fixes #97 